### PR TITLE
fix: Only update firedragon.desktop when file changes

### DIFF
--- a/org.garudalinux.firedragon.yml
+++ b/org.garudalinux.firedragon.yml
@@ -81,8 +81,8 @@ modules:
         sha256: 53d3e743f3750522318a786befa196237892c93f20571443fdf82a480e7f0560
         x-checker-data:
           type: json
-          url: https://gitlab.com/api/v4/projects/24557372/repository/commits/master
-          version-query: .id
+          url: https://gitlab.com/api/v4/projects/24557372/repository/files/firedragon.desktop?ref=master
+          version-query: .last_commit_id
           url-query: '"https://gitlab.com/garuda-linux/firedragon/settings/-/raw/\($version)/firedragon.desktop"'
       - type: file
         path: org.garudalinux.firedragon.metainfo.xml


### PR DESCRIPTION
Configure flatpak-external-data-checker to update firedragon.desktop only when the file changes by using the GitLab Repository Files API.