### PR TITLE
Update runtime to 25.08

### DIFF
--- a/org.garudalinux.firedragon.yml
+++ b/org.garudalinux.firedragon.yml
@@ -1,14 +1,9 @@
 app-id: org.garudalinux.firedragon
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
-base-version: '24.08'
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
+base-version: '25.08'
 command: firedragon
 finish-args:
   - --allow=devel


### PR DESCRIPTION
Also, drop the ffmpeg extension 

> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like 

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/